### PR TITLE
Minor oversight: 'FreeBSD' should be 'bayes-scala'

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -23,4 +23,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
 of the authors and should not be interpreted as representing official policies, 
-either expressed or implied, of the FreeBSD Project.
+either expressed or implied, of the bayes-scala Project.


### PR DESCRIPTION
It looks like a standard BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause).
However, I guess the reference to 'FreeBSD' in the additional disclaimer is a minor oversight.
