### PR TITLE
Set plugin version for better stability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
 	<!-- Properties -->
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<scala.version>2.10.3</scala.version>
 		<junit.version>4.4</junit.version>
 		<maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>


### PR DESCRIPTION
Minimum changes required to improve build stability.
1) Fix plugin versions (maven-scala-plugin)
2) Specify minimum maven version

Notes : an even higher version of Maven could be set as prerequisite (3.0.5+), maven-eclipse-plugin could be upgraded (2.8 -> 2.9).
